### PR TITLE
Update link for strata scratch connection notebook

### DIFF
--- a/Pandas_Tutorial.ipynb
+++ b/Pandas_Tutorial.ipynb
@@ -498,7 +498,7 @@
         "\n",
         "Python allows you to connect to any type of database. To make this easy for newbies, we've create a notebook to help you connect to the Strata Scratch platform and pull data. Use the notebook below to pull data from our database.\n",
         "\n",
-        "[Connect to Strata Scratch with Python](https://colab.research.google.com/drive/1VtywiAAI-ucfTzBa6YDca8k4gfGiEPnn)"
+        "[Connect to Strata Scratch with Python](https://colab.research.google.com/drive/1tHxAbgbxM60VUIrVQW508EwB1b3wFk5g)"
       ]
     },
     {


### PR DESCRIPTION
The link included in the pandas tutorial notebook: [Connect to Strata Scratch with Python](https://colab.research.google.com/drive/1VtywiAAI-ucfTzBa6YDca8k4gfGiEPnn) is broken.

I found the correct link to the source notebook below:
https://colab.research.google.com/drive/1tHxAbgbxM60VUIrVQW508EwB1b3wFk5g

This pull request only changes the link to the correct version. 