### PR TITLE
Fixed model1/model2 typo

### DIFF
--- a/AQ_Example.ipynb
+++ b/AQ_Example.ipynb
@@ -1203,7 +1203,7 @@
       ],
       "source": [
         "# repeat plot for AQ3\n",
-        "sns.lmplot(data=aq1, x=\"x\", y=\"y\")"
+        "sns.lmplot(data=aq3, x=\"x\", y=\"y\")"
       ]
     },
     {
@@ -1243,7 +1243,7 @@
       ],
       "source": [
         "# repeat plot for AQ4\n",
-        "sns.lmplot(data=aq1, x=\"x\", y=\"y\")"
+        "sns.lmplot(data=aq4, x=\"x\", y=\"y\")"
       ]
     },
     {

--- a/OLSRegression.ipynb
+++ b/OLSRegression.ipynb
@@ -1671,7 +1671,7 @@
     }
    ],
    "source": [
-    "sm.graphics.plot_fit(model1,1, vlines=False);"
+    "sm.graphics.plot_fit(model2,1, vlines=False);"
    ]
   }
  ],


### PR DESCRIPTION
The last cell of the notebook calls a model named "model1" which does not exist. The file only has a model and a model2.