### PR TITLE
Infer nfolds directly in printLassoRMSE function

### DIFF
--- a/Session 5_Lasso_Chimera_example.ipynb
+++ b/Session 5_Lasso_Chimera_example.ipynb
@@ -234,7 +234,7 @@
         "    \n",
         "# define function to print RMSE of each lasso model\n",
         "def printLassoRMSE(cvlasso,X,y):\n",
-        "  nfolds = cvlasso.mse_path_.shape[-1] #infer number of folds from output shape\n"
+        "  nfolds = cvlasso.mse_path_.shape[-1] #infer number of folds from output shape\n",
         "  Rmse=-1*cross_val_score(cvlasso,X,y, cv=nfolds,scoring='neg_root_mean_squared_error')\n",
         "  print(\"RMSE of each fold\", [round(num, 4) for num in Rmse])\n",
         "  print(\"mean RMSE of folds\", round(np.mean(Rmse),4))\n",

--- a/Session 5_Lasso_Chimera_example.ipynb
+++ b/Session 5_Lasso_Chimera_example.ipynb
@@ -234,6 +234,7 @@
         "    \n",
         "# define function to print RMSE of each lasso model\n",
         "def printLassoRMSE(cvlasso,X,y):\n",
+        "  nfolds = cvlasso.mse_path_.shape[-1] #infer number of folds from output shape\n"
         "  Rmse=-1*cross_val_score(cvlasso,X,y, cv=nfolds,scoring='neg_root_mean_squared_error')\n",
         "  print(\"RMSE of each fold\", [round(num, 4) for num in Rmse])\n",
         "  print(\"mean RMSE of folds\", round(np.mean(Rmse),4))\n",


### PR DESCRIPTION
Currently, the nfolds in printLassoRMSE are read from the global variable nfolds. This means if the notebook user changes the value for cv directly in the lassocv function rather than changing the global variable, it won't update to the value the user set and when the user runs printLassoRMSE, it will only print the first 3 values. By adding a line to the function definition to infer the value for nfolds directly from the model object, this problem is avoided and makes the notebook a bit more user friendly for beginners. 

The code:

cvlasso.mse_path_.shape[-1] 

Returns the length of the last dimension of the array. So for a 1d array (when alpha is set to a single value), it will return the length of the 1d array which is equal to the number of folds. For a 2d array (when alpha is set to an array of regularization parameters to try), it will return the length of the first column of the 2d array which is also equal to the number of folds. 

mse_path_ is an attribute of the lassocv object of shape (nalphas, nfolds)

See documentation here: https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoCV.html for more detail.